### PR TITLE
fixed duplicated data

### DIFF
--- a/logrus_influxdb.go
+++ b/logrus_influxdb.go
@@ -93,14 +93,20 @@ func (hook *InfluxDBHook) Fire(entry *logrus.Entry) (err error) {
 		tags["logger"] = logger
 	}
 
+	// make a copy of entry.Data
+	data := make(map[string]interface{})
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+
 	for _, tag := range hook.tagList {
 		if tagValue, ok := getTag(entry.Data, tag); ok {
 			tags[tag] = tagValue
-			delete(map[string]interface{}(entry.Data), tag)
+			delete(data, tag)
 		}
 	}
 
-	pt, err := influxdb.NewPoint(measurement, tags, entry.Data, entry.Time)
+	pt, err := influxdb.NewPoint(measurement, tags, data, entry.Time)
 	if err != nil {
 		return fmt.Errorf("Fire: %v", err)
 	}

--- a/logrus_influxdb.go
+++ b/logrus_influxdb.go
@@ -21,14 +21,14 @@ var (
 
 // InfluxDBHook delivers logs to an InfluxDB cluster.
 type InfluxDBHook struct {
-	sync.Mutex          // TODO: we should clean up all of these locks
-	client              influxdb.Client
+	sync.Mutex                       // TODO: we should clean up all of these locks
+	client                           influxdb.Client
 	precision, database, measurement string
-	tagList             []string
-	batchP              influxdb.BatchPoints
-	lastBatchUpdate     time.Time
-	batchInterval       time.Duration
-	batchCount          int
+	tagList                          []string
+	batchP                           influxdb.BatchPoints
+	lastBatchUpdate                  time.Time
+	batchInterval                    time.Duration
+	batchCount                       int
 }
 
 // NewInfluxDB returns a new InfluxDBHook.
@@ -59,7 +59,7 @@ func NewInfluxDB(config *Config, clients ...influxdb.Client) (hook *InfluxDBHook
 	hook = &InfluxDBHook{
 		client:        client,
 		database:      config.Database,
-		measurement:	 config.Measurement,
+		measurement:   config.Measurement,
 		tagList:       config.Tags,
 		batchInterval: config.BatchInterval,
 		batchCount:    config.BatchCount,
@@ -96,6 +96,7 @@ func (hook *InfluxDBHook) Fire(entry *logrus.Entry) (err error) {
 	for _, tag := range hook.tagList {
 		if tagValue, ok := getTag(entry.Data, tag); ok {
 			tags[tag] = tagValue
+			delete(map[string]interface{}(entry.Data), tag)
 		}
 	}
 


### PR DESCRIPTION
is see duplicated data when i set some tags ( for example []string{"name", "huhn"})
and log some data

```
log.WithFields(logrus.Fields{
    "name": "zhangsan",
    "age":  rand.Intn(100),
    "huhn": "großes huhn",
}).Error("Hello world!")
```

the problem was that the data was written as a tag and once again as a field

before: 
![influx1](https://cloud.githubusercontent.com/assets/16866547/18419327/7d70ab6c-7858-11e6-8608-3eb955a49c39.jpg)

after:
![influx2](https://cloud.githubusercontent.com/assets/16866547/18419330/887134b4-7858-11e6-98cb-286abd75b3c8.jpg)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/abramovic/logrus_influxdb/17)

<!-- Reviewable:end -->
